### PR TITLE
Migrate `relocate_sdk.py` to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ existing toolkits in your Arduino installation (Note: you need to "fail" to inst
 the Arduino packages *first*). It makes adjustments to the installations as needed
 to allow them to then work.
 
-**Note:** Requires Python 2 to be installed (sudo apt install python2)
+**Note:** Requires Python 2 to be installed (`sudo apt install python2`), for edison only.
 
 **Another note:** Edison script is currently broken - it can't find the download file.
 Maybe it's redundant now?

--- a/fixgalileo.sh
+++ b/fixgalileo.sh
@@ -17,7 +17,7 @@ wget -c ${URL}
 rm -rf "${DEST}/i586"
 mkdir -p "${DEST}"
 tar -C "${DEST}" -jxf ${FILE}
+cp relocate_sdk_py3.py "${DEST}/i586/relocate_sdk.py"
 cd "${DEST}/i586"
 sed -i 's/-perm +111/-perm \/111/g' install_script.sh
-sed -i 's/^#!\/usr\/bin\/env python$/#!\/usr\/bin\/env python2/g' relocate_sdk.py
 ./install_script.sh

--- a/relocate_sdk_py3.py
+++ b/relocate_sdk_py3.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python2
+#
+# Copyright (c) 2012 Intel Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+# DESCRIPTION
+# This script is called by the SDK installer script. It replaces the dynamic
+# loader path in all binaries and also fixes the SYSDIR paths/lengths and the
+# location of ld.so.cache in the dynamic loader binary
+#
+# AUTHORS
+# Laurentiu Palcu <laurentiu.palcu@intel.com>
+#
+
+import struct
+import sys
+import stat
+import os
+import re
+import errno
+
+old_prefix = re.compile("/opt/clanton-tiny/1\.4\.2")
+
+def get_arch():
+    f.seek(0)
+    e_ident =f.read(16)
+    ei_mag0,ei_mag1_3,ei_class = struct.unpack("<B3sB11x", e_ident)
+
+    if (ei_mag0 != 0x7f and ei_mag1_3 != "ELF") or ei_class == 0:
+        return 0
+
+    if ei_class == 1:
+        return 32
+    elif ei_class == 2:
+        return 64
+
+def parse_elf_header():
+    global e_type, e_machine, e_version, e_entry, e_phoff, e_shoff, e_flags,\
+           e_ehsize, e_phentsize, e_phnum, e_shentsize, e_shnum, e_shstrndx
+
+    f.seek(0)
+    elf_header = f.read(64)
+
+    if arch == 32:
+        # 32bit
+        hdr_fmt = "<HHILLLIHHHHHH"
+        hdr_size = 52
+    else:
+        # 64bit
+        hdr_fmt = "<HHIQQQIHHHHHH"
+        hdr_size = 64
+
+    e_type, e_machine, e_version, e_entry, e_phoff, e_shoff, e_flags,\
+    e_ehsize, e_phentsize, e_phnum, e_shentsize, e_shnum, e_shstrndx =\
+        struct.unpack(hdr_fmt, elf_header[16:hdr_size])
+
+def change_interpreter(elf_file_name):
+    if arch == 32:
+        ph_fmt = "<IIIIIIII"
+    else:
+        ph_fmt = "<IIQQQQQQ"
+
+    """ look for PT_INTERP section """
+    for i in range(0,e_phnum):
+        f.seek(e_phoff + i * e_phentsize)
+        ph_hdr = f.read(e_phentsize)
+        if arch == 32:
+            # 32bit
+            p_type, p_offset, p_vaddr, p_paddr, p_filesz,\
+                p_memsz, p_flags, p_align = struct.unpack(ph_fmt, ph_hdr)
+        else:
+            # 64bit
+            p_type, p_flags, p_offset, p_vaddr, p_paddr, \
+            p_filesz, p_memsz, p_align = struct.unpack(ph_fmt, ph_hdr)
+
+        """ change interpreter """
+        if p_type == 3:
+            # PT_INTERP section
+            f.seek(p_offset)
+            # External SDKs with mixed pre-compiled binaries should not get
+            # relocated so look for some variant of /lib
+            fname = f.read(11)
+            if fname.startswith("/lib/") or fname.startswith("/lib64/") or fname.startswith("/lib32/") or fname.startswith("/usr/lib32/") or fname.startswith("/usr/lib32/") or fname.startswith("/usr/lib64/"):
+                break
+            if (len(new_dl_path) >= p_filesz):
+                print "ERROR: could not relocate %s, interp size = %i and %i is needed." % (elf_file_name, p_memsz, len(new_dl_path) + 1)
+                break
+            dl_path = new_dl_path + "\0" * (p_filesz - len(new_dl_path))
+            f.seek(p_offset)
+            f.write(dl_path)
+            break
+
+def change_dl_sysdirs():
+    if arch == 32:
+        sh_fmt = "<IIIIIIIIII"
+    else:
+        sh_fmt = "<IIQQQQIIQQ"
+
+    """ read section string table """
+    f.seek(e_shoff + e_shstrndx * e_shentsize)
+    sh_hdr = f.read(e_shentsize)
+    if arch == 32:
+        sh_offset, sh_size = struct.unpack("<16xII16x", sh_hdr)
+    else:
+        sh_offset, sh_size = struct.unpack("<24xQQ24x", sh_hdr)
+
+    f.seek(sh_offset)
+    sh_strtab = f.read(sh_size)
+
+    sysdirs = sysdirs_len = ""
+
+    """ change ld.so.cache path and default libs path for dynamic loader """
+    for i in range(0,e_shnum):
+        f.seek(e_shoff + i * e_shentsize)
+        sh_hdr = f.read(e_shentsize)
+
+        sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size, sh_link,\
+            sh_info, sh_addralign, sh_entsize = struct.unpack(sh_fmt, sh_hdr)
+
+        name = sh_strtab[sh_name:sh_strtab.find("\0", sh_name)]
+
+        """ look only into SHT_PROGBITS sections """
+        if sh_type == 1:
+            f.seek(sh_offset)
+            """ default library paths cannot be changed on the fly because  """
+            """ the string lengths have to be changed too.                  """
+            if name == ".sysdirs":
+                sysdirs = f.read(sh_size)
+                sysdirs_off = sh_offset
+                sysdirs_sect_size = sh_size
+            elif name == ".sysdirslen":
+                sysdirslen = f.read(sh_size)
+                sysdirslen_off = sh_offset
+            elif name == ".ldsocache":
+                ldsocache_path = f.read(sh_size)
+                new_ldsocache_path = old_prefix.sub(new_prefix, ldsocache_path)
+                # pad with zeros
+                new_ldsocache_path += "\0" * (sh_size - len(new_ldsocache_path))
+                # write it back
+                f.seek(sh_offset)
+                f.write(new_ldsocache_path)
+
+    if sysdirs != "" and sysdirslen != "":
+        paths = sysdirs.split("\0")
+        sysdirs = ""
+        sysdirslen = ""
+        for path in paths:
+            """ exit the loop when we encounter first empty string """
+            if path == "":
+                break
+
+            new_path = old_prefix.sub(new_prefix, path)
+            sysdirs += new_path + "\0"
+
+            if arch == 32:
+                sysdirslen += struct.pack("<L", len(new_path))
+            else:
+                sysdirslen += struct.pack("<Q", len(new_path))
+
+        """ pad with zeros """
+        sysdirs += "\0" * (sysdirs_sect_size - len(sysdirs))
+
+        """ write the sections back """
+        f.seek(sysdirs_off)
+        f.write(sysdirs)
+        f.seek(sysdirslen_off)
+        f.write(sysdirslen)
+
+
+# MAIN
+if len(sys.argv) < 4:
+    sys.exit(-1)
+
+new_prefix = sys.argv[1]
+new_dl_path = sys.argv[2]
+executables_list = sys.argv[3:]
+
+for e in executables_list:
+    perms = os.stat(e)[stat.ST_MODE]
+    if os.access(e, os.W_OK|os.R_OK):
+        perms = None
+    else:
+        os.chmod(e, perms|stat.S_IRWXU)
+
+    try:
+        f = open(e, "r+b")
+    except IOError, ioex:
+        if ioex.errno == errno.ETXTBSY:
+            print("Could not open %s. File used by another process.\nPlease "\
+                  "make sure you exit all processes that might use any SDK "\
+                  "binaries." % e)
+        else:
+            print("Could not open %s: %s(%d)" % (e, ioex.strerror, ioex.errno))
+        sys.exit(-1)
+
+    arch = get_arch()
+    if arch:
+        parse_elf_header()
+        change_interpreter(e)
+        change_dl_sysdirs()
+
+    """ change permissions back """
+    if perms:
+        os.chmod(e, perms)
+
+    f.close()
+

--- a/relocate_sdk_py3.py
+++ b/relocate_sdk_py3.py
@@ -95,7 +95,7 @@ def change_interpreter(elf_file_name):
             if fname.startswith("/lib/") or fname.startswith("/lib64/") or fname.startswith("/lib32/") or fname.startswith("/usr/lib32/") or fname.startswith("/usr/lib32/") or fname.startswith("/usr/lib64/"):
                 break
             if (len(new_dl_path) >= p_filesz):
-                print "ERROR: could not relocate %s, interp size = %i and %i is needed." % (elf_file_name, p_memsz, len(new_dl_path) + 1)
+                print("ERROR: could not relocate %s, interp size = %i and %i is needed." % (elf_file_name, p_memsz, len(new_dl_path) + 1))
                 break
             dl_path = new_dl_path + "\0" * (p_filesz - len(new_dl_path))
             f.seek(p_offset)
@@ -196,13 +196,13 @@ for e in executables_list:
 
     try:
         f = open(e, "r+b")
-    except IOError, ioex:
+    except IOError as ioex:
         if ioex.errno == errno.ETXTBSY:
-            print("Could not open %s. File used by another process.\nPlease "\
+            print(("Could not open %s. File used by another process.\nPlease "\
                   "make sure you exit all processes that might use any SDK "\
-                  "binaries." % e)
+                  "binaries." % e))
         else:
-            print("Could not open %s: %s(%d)" % (e, ioex.strerror, ioex.errno))
+            print(("Could not open %s: %s(%d)" % (e, ioex.strerror, ioex.errno)))
         sys.exit(-1)
 
     arch = get_arch()


### PR DESCRIPTION
Most recent linux distros have removed python 2 from their repositories.
It's generally a _pain_ to install it, when the best course of action is to migrate this Intel galileo arduino helper python script to be compatible with python 3.

This PR addresses this problem, and thus prolonging the life of this hardware a bit more.
This is based heavily on this patch:
https://git.openembedded.org/openembedded-core-contrib/commit/?id=175f20e27eadc79df16109961f5ce6232705e96f
And this alternative version of this script:
https://github.com/openembedded/openembedded-core/blob/master/scripts/relocate_sdk.py

I tested this on my Debian 12 (bookworm) machine (without `python2`), using system python version `3.11.2`.

```
Setting it up.../tmp/tmp.rKv8FlAcWz/relocate_sdk.sh /home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/relocate_sdk.sh
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libanl.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libnss_dns.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libnss_compat.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libncurses.so.5
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libc.so.6
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libm.so.6
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libnsl.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libnss_files.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libresolv.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libutil.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libBrokenLocale.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libtinfo.so.5
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/librt.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libcrypt.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/ld-linux.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libpthread.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/lib/libdl.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/etc/terminfo/x/xterm
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/etc/ld.so.cache
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/perl/5.14.3/Config_heavy-target.pl
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libasm.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libmpfr.so.4
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libz.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libgthread-2.0.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_ppc64.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_sh.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_x86_64.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_parisc.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_arm.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_ppc.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_mips.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_sparc.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_ia64.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_s390.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_alpha.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_m68k.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/elfutils/libebl_i386.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libbz2.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libffi.so.6
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libmpc.so.2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libgio-2.0.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libgobject-2.0.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libgmp.so.10
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libpng16.so.16
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libglib-2.0.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libhistory.so.6
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libopkg.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libpixman-1.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libdw.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libreadline.so.6
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libSDL-1.2.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libperl.so.5
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libexpat.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libelf.so.1
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/perl5
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libgmodule-2.0.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/lib/libssp.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/liblto_plugin.so
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/ranlib
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/ld
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/nm
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/strip
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/ar
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/gcc
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/objdump
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/objcopy
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/as
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/cpp
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/libexec/i586-poky-linux-uclibc/gcc/i586-poky-linux-uclibc/4.7.2/liblto_plugin.so.0
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/flash2raw.terrier
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/flash2raw.akita
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/perl.real
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/python
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/python2-config
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/raw2flash.akita
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/raw2flash.borzoi
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/python-config
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/python2
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/flash2raw.borzoi
link:/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/raw2flash.terrier
sed: can't read /home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/gnu-configize
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/aclocal
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/autom4te
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/autoheader
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/automake-1.12
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/ifnames
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/automake
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/aclocal-1.12
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/autoscan
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/autoupdate
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/bin/autoreconf
/home/candres/.arduino15/packages/Intel/tools/i586-poky-linux-uclibc/1.6.2+1.0/i586/sysroots/i586-pokysdk-linux/usr/share/automake-1.12/tap-driver.pl: No such file or directory
done
SDK has been successfully set up and is ready to be used.
```

I was able to load the basic `blink` example to an Intel Galileo Gen 2 board successfully using the Arduino IDE (v.1.8.19), however, I did notice some "no file found" errors messages in the above, script output and also in the Arduino Console:

`Invalid library found in /home/candres/.arduino15/packages/Intel/hardware/i586/1.6.2+1.0/libraries/Wire: no headers files (.h) found in /home/candres/.arduino15/packages/Intel/hardware/i586/1.6.2+1.0/libraries/Wire`

Not sure these are important.